### PR TITLE
Fix import of gonum

### DIFF
--- a/lib/plot.go
+++ b/lib/plot.go
@@ -3,12 +3,12 @@ package lib
 import (
 	"io"
 
-	"github.com/gonum/plot"
-	"github.com/gonum/plot/plotter"
-	"github.com/gonum/plot/plotutil"
-	"github.com/gonum/plot/vg"
-	"github.com/gonum/plot/vg/draw"
-	"github.com/gonum/plot/vg/vgimg"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/plotutil"
+	"gonum.org/v1/plot/vg"
+	"gonum.org/v1/plot/vg/draw"
+	"gonum.org/v1/plot/vg/vgimg"
 )
 
 const dpi = 96


### PR DESCRIPTION
When go getting or building stargraph, was getting the following error messages:

```$ make build

go fmt
go vet
lib/plot.go:6:2: code in directory /Users/rfreixo/go/src/github.com/gonum/plot expects import "gonum.org/v1/plot"
lib/plot.go:7:2: code in directory /Users/rfreixo/go/src/github.com/gonum/plot/plotter expects import "gonum.org/v1/plot/plotter"
lib/plot.go:8:2: code in directory /Users/rfreixo/go/src/github.com/gonum/plot/plotutil expects import "gonum.org/v1/plot/plotutil"
lib/plot.go:9:2: code in directory /Users/rfreixo/go/src/github.com/gonum/plot/vg expects import "gonum.org/v1/plot/vg"
lib/plot.go:10:2: code in directory /Users/rfreixo/go/src/github.com/gonum/plot/vg/draw expects import "gonum.org/v1/plot/vg/draw"
lib/plot.go:11:2: code in directory /Users/rfreixo/go/src/github.com/gonum/plot/vg/vgimg expects import "gonum.org/v1/plot/vg/vgimg"
make: *** [build] Error 1
```

Seems to be because gonum has since moved to a new home, and expects a new import path/URL now.

These changes allow it to be built again.